### PR TITLE
Added predetemined categories

### DIFF
--- a/db/crud.py
+++ b/db/crud.py
@@ -48,6 +48,8 @@ def get_user_by_email(email):
         session.close()
 
 
+
+#function for updating your password
 def update_password(email, new_password) -> tuple[bool, User | str]:
     session = SessionLocal()
     try:

--- a/db/crud.py
+++ b/db/crud.py
@@ -126,3 +126,8 @@ def get_category():
         return session.query(Category).all()
     finally:
         session.close()
+
+def pre_categories():
+    categories = ["Salary", "Food & Groceries", "Rent & Housing", "Entertainment"]
+    for name in categories:
+        create_category(name)

--- a/db/database.py
+++ b/db/database.py
@@ -16,3 +16,6 @@ def init_db():
     Adds all missing tables.
     '''
     Base.metadata.create_all(engine)
+    from db.crud import pre_categories
+    pre_categories()
+    

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -127,6 +127,7 @@ def test_get_user_by_email():
     assert user is not None
     assert user.username == "gresah"
     assert user.password == "mypassword"
+<<<<<<< HEAD
 
 
 def test_get_users():
@@ -136,3 +137,17 @@ def test_get_users():
     assert len(users) == 2
     assert users[0].username == "Messiah"
     assert users[1].password == "smile"
+=======
+# Exsisting category
+
+def test_create_transaction_invalid_category():
+    success, msg = crud.create_transaction(
+        user_id = 1,
+        amount = 50,
+        category_id = 999,  
+        date=date(2024, 1, 1),
+        description = "Invalid category test"
+    )
+
+    assert success is False
+>>>>>>> 92c8e15 (Merge for branch)

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -127,7 +127,6 @@ def test_get_user_by_email():
     assert user is not None
     assert user.username == "gresah"
     assert user.password == "mypassword"
-<<<<<<< HEAD
 
 
 def test_get_users():
@@ -137,17 +136,3 @@ def test_get_users():
     assert len(users) == 2
     assert users[0].username == "Messiah"
     assert users[1].password == "smile"
-=======
-# Exsisting category
-
-def test_create_transaction_invalid_category():
-    success, msg = crud.create_transaction(
-        user_id = 1,
-        amount = 50,
-        category_id = 999,  
-        date=date(2024, 1, 1),
-        description = "Invalid category test"
-    )
-
-    assert success is False
->>>>>>> 92c8e15 (Merge for branch)

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -20,6 +20,8 @@ def setup_db(monkeypatch):
     # override SessionLocal in crud
     monkeypatch.setattr(crud, "SessionLocal", TestingSessionLocal)
 
+    crud.pre_categories()
+
     yield
 
     Base.metadata.drop_all(engine)
@@ -81,7 +83,7 @@ def test_create_transaction_success():
     success, transaction = crud.create_transaction(
         user_id=1,
         amount=100,
-        category_id=1,
+        category_id=cat_id,
         date=date(2024, 1, 1),
         description="Lunch"
     )


### PR DESCRIPTION
I added a function that adds the decided predetermined categories "Salary", "Food & Groceries", "Rent & Housing", and "Entertainment". I also added for it to call `pre_categories` in `init_db´ for easy pickup for the backend. 

Why I have `from db.crud import pre_categories` in `def init()` is to avoid circular import. Because `crud.py` already imports from `database.py`, if also imported `crud.py` at top of the `database.py` they would import eachother and chrash the program. 