### PR TITLE
Exclude files from coverage testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,9 @@ pythonpath = ["."]
 run = "flask run"
 test = "pytest test/ -v --cov=. --cov-report=term-missing --cov-report=html"
 lint = "flake8 db/ test/ app.py db_test.py"
+
+[tool.coverage.run]
+omit = [
+    "db_test.py",
+    "test/*"
+]


### PR DESCRIPTION
We need to exclude certain files from coverage testing as they are skewing our results. Resolves #133 