### PR TITLE
Add get_balance, add_salary and add_expense

### DIFF
--- a/db/crud.py
+++ b/db/crud.py
@@ -48,6 +48,8 @@ def get_user_by_email(email):
         session.close()
 
 
+
+#function for updating your password
 def update_password(email, new_password) -> tuple[bool, User | str]:
     session = SessionLocal()
     try:

--- a/db/crud.py
+++ b/db/crud.py
@@ -131,3 +131,19 @@ def pre_categories():
     categories = ["Salary", "Food & Groceries", "Rent & Housing", "Entertainment"]
     for name in categories:
         create_category(name)
+
+
+def get_balance(user_id):
+    session = SessionLocal()
+    try:
+        transactions = session.query(Transaction).filter(Transaction.user_id == user_id).all()
+        return sum(t.amount for t in transactions)
+    finally:
+        session.close()
+
+def add_salary(user_id, amount, category_id, date, description = None):
+    return create_transaction(user_id, abs(amount), category_id, date, description)
+
+
+def add_expenses(user_id, amount, category_id, date, description=None):
+    return create_transaction(user_id, -abs(amount), category_id, date, description)

--- a/db/crud.py
+++ b/db/crud.py
@@ -126,3 +126,8 @@ def get_category():
         return session.query(Category).all()
     finally:
         session.close()
+
+def pre_categories():
+    categories = ["Salary", "Food & Groceries", "Rent & Housing", "Entertainment"]
+    for name in categories:
+        create_category(name)

--- a/db/database.py
+++ b/db/database.py
@@ -16,3 +16,6 @@ def init_db():
     Adds all missing tables.
     '''
     Base.metadata.create_all(engine)
+    from db.crud import pre_categories
+    pre_categories()
+    

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -127,6 +127,7 @@ def test_get_user_by_email():
     assert user is not None
     assert user.username == "gresah"
     assert user.password == "mypassword"
+<<<<<<< HEAD
 
 
 def test_get_users():
@@ -136,3 +137,17 @@ def test_get_users():
     assert len(users) == 2
     assert users[0].username == "Messiah"
     assert users[1].password == "smile"
+=======
+# Exsisting category
+
+def test_create_transaction_invalid_category():
+    success, msg = crud.create_transaction(
+        user_id = 1,
+        amount = 50,
+        category_id = 999,  
+        date=date(2024, 1, 1),
+        description = "Invalid category test"
+    )
+
+    assert success is False
+>>>>>>> 92c8e15 (Merge for branch)

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -127,7 +127,6 @@ def test_get_user_by_email():
     assert user is not None
     assert user.username == "gresah"
     assert user.password == "mypassword"
-<<<<<<< HEAD
 
 
 def test_get_users():
@@ -137,17 +136,3 @@ def test_get_users():
     assert len(users) == 2
     assert users[0].username == "Messiah"
     assert users[1].password == "smile"
-=======
-# Exsisting category
-
-def test_create_transaction_invalid_category():
-    success, msg = crud.create_transaction(
-        user_id = 1,
-        amount = 50,
-        category_id = 999,  
-        date=date(2024, 1, 1),
-        description = "Invalid category test"
-    )
-
-    assert success is False
->>>>>>> 92c8e15 (Merge for branch)

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -138,3 +138,12 @@ def test_get_users():
     assert len(users) == 2
     assert users[0].username == "Messiah"
     assert users[1].password == "smile"
+
+def test_get_balance():
+
+    crud.create_transaction(user_id=1, amount=25000, category_id=1, date=date(2024, 1, 1))
+    crud.create_transaction(user_id=1, amount=-500, category_id=2, date=date(2024, 1, 2))
+
+    balance = crud.get_balance(1)
+
+    assert balance == 24500

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -20,6 +20,8 @@ def setup_db(monkeypatch):
     # override SessionLocal in crud
     monkeypatch.setattr(crud, "SessionLocal", TestingSessionLocal)
 
+    crud.pre_categories()
+
     yield
 
     Base.metadata.drop_all(engine)
@@ -81,7 +83,7 @@ def test_create_transaction_success():
     success, transaction = crud.create_transaction(
         user_id=1,
         amount=100,
-        category_id=1,
+        category_id=cat_id,
         date=date(2024, 1, 1),
         description="Lunch"
     )


### PR DESCRIPTION
## crud.py 
- `get_balance()` — calculates total balance for all transactions for a user
- `add_salary()` — creates a positive transaction (salary)
- `add_expense()` — creates a negative transaction (expense)

Added `add_salary` and `add_expense` mostly to make it easier to call. So that @hogr24bj and @peel24jb in the backend don't have to think about writing  + and - code.  But if you would rather want to use `create_transaction()` directly and set the + and - for salary and exepeses yourself that's totally fine, what do you think? :-)

## test_crud.py
- `test_get_balance()` — checks that balance is calculated correctly with mixed transactions (salary + expense)
