### PR TITLE
implemented issue #145 and updated my daily scrum

### DIFF
--- a/sprint/daily_scrum3.md
+++ b/sprint/daily_scrum3.md
@@ -75,9 +75,9 @@
 - Next:
 
 24/4
-- Did:
-- Blockers:
-- Next:
+- Did: ntegration testing was added to verify the interaction between Flask routes, session handling, and the database layer using an isolated in‑memory SQLite database.
+- Blockers: None
+- Next: Continue with issues. 
 
 
 ## Gresa Hoxha

--- a/test/test_integration_app.py
+++ b/test/test_integration_app.py
@@ -1,0 +1,61 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app import app
+from db.database import Base
+import db.crud as crud
+
+
+engine = create_engine("sqlite:///:memory:")
+TestingSessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Create tables
+    Base.metadata.create_all(engine)
+
+    # Patch SessionLocal in crud
+    monkeypatch.setattr(crud, "SessionLocal", TestingSessionLocal)
+
+    crud.pre_categories()
+
+    app.config["TESTING"] = True
+    app.config["SECRET_KEY"] = "test-secret"
+
+    with app.test_client() as client:
+        yield client
+
+    Base.metadata.drop_all(engine)
+
+
+def test_login_and_access_dashboard(client):
+    # Arrange: create user in DB
+    success, user = crud.create_user(
+        "test@test.com",
+        "Test",
+        "User",
+        "testuser",
+        "password"
+    )
+    assert success is True
+
+    # Act: login via route
+    response = client.post(
+        "/login",
+        data={
+            "email": "test@test.com",
+            "password": "password"
+        },
+        follow_redirects=False
+    )
+
+    # Assert: redirect to dashboard
+    assert response.status_code == 302
+    assert "/dashboard" in response.headers["Location"]
+
+    # Follow redirect
+    dashboard_response = client.get("/dashboard")
+    assert dashboard_response.status_code == 200
+    assert b"Remaining Budget" in dashboard_response.data


### PR DESCRIPTION
## Description
This pull request adds an integration test that verifies the interaction between
Flask routes, session handling, and the database layer.

The test covers the full flow:
- Create a user in the database
- Log in via the `/login` route
- Access the protected `/dashboard` route
- Verify that the dashboard is rendered successfully

## Why
We already have unit tests for the CRUD layer and database models.
This integration test ensures that the backend components work correctly together,
including routes, sessions, and database access.

## Tests
- Added `test_integration_app.py`
- Uses pytest with an isolated in‑memory SQLite database
- No mocking of CRUD or database logic

## How to test
```bash
pytest
# or
python3 -m pytest test/test_integration_app.py -v
``