### PR TITLE
Add individual user goal handling

### DIFF
--- a/db/crud.py
+++ b/db/crud.py
@@ -99,6 +99,30 @@ def update_password(email, new_password) -> tuple[bool, User | str]:
         session.close()
 
 
+def update_goal(email, amount) -> tuple[bool, User | str]:
+    '''
+    Update a single users monthly goal.\n
+    If we want to remove the goal we can use None for the amount, as the field is nullable in the DB.
+    '''
+    session = SessionLocal()
+    try:
+        user = session.query(User).filter(User.email == email).first()
+
+        if not user:
+            return False, "No account with that email"
+        
+        user.goal = amount
+        session.commit()
+        return True, user
+    
+    except IntegrityError as e:
+        session.rollback()
+        return False, "Could not update goal"   # fallback
+
+    finally:
+        session.close()
+
+
 def create_transaction(user_id, amount, category_id, date, description = None) -> tuple[bool, Transaction | str]:
     session = SessionLocal()
 

--- a/db/models.py
+++ b/db/models.py
@@ -15,6 +15,7 @@ class User(Base):
     lastname = Column(String, nullable=False)
     username = Column(String, unique=True, nullable=False)
     password = Column(String, nullable=False)
+    goal = Column(Integer, nullable=True)
 
 
 class Transaction(Base): 

--- a/db_test.py
+++ b/db_test.py
@@ -1,4 +1,4 @@
-from db.crud import create_user, get_users, create_transaction, get_transaction, create_category, get_category
+from db.crud import create_user, get_users, create_transaction, get_transaction, create_category, get_category, update_goal
 from db.database import init_db
 from datetime import date as Date
 
@@ -69,6 +69,18 @@ def print_categories():
         print({k: v for k, v in vars(c).items() if not k.startswith("_")})
 
 
+def update_user_goal():
+    email = input("User email: ")
+    amount = input("Amount: ")
+    amount = None if amount.strip() in ("", "None", "none") else int(amount)
+    success, result = update_goal(email, amount)
+
+    if success:
+        print("\nGoal updated.")
+    else:
+        print(f"\nError: {result}")
+        
+
 def menu():
     print("\n--- BudgetBuddy DB Test ---")
     print("1. Add user")
@@ -77,6 +89,7 @@ def menu():
     print("4. Show transactions")
     print("5. Add category")
     print("6. Show categories")
+    print("7. Update user goal")
     print("0. Exit")
 
 
@@ -105,6 +118,9 @@ def main():
 
         elif choice == "6":
             print_categories()
+
+        elif choice == "7":
+            update_user_goal()
 
         elif choice == "0":
             print("\nExiting...")

--- a/test/test_crud.py
+++ b/test/test_crud.py
@@ -175,3 +175,23 @@ def test_get_category():
     categories = crud.get_category()
     assert len(categories) == 5
     assert categories[0].name == "Salary"
+
+def test_update_goal_success():
+    crud.create_user("goal@test.com", "A", "B", "goaluser", "pass")
+    success, user = crud.update_goal("goal@test.com", 5000)
+    assert success is True
+    assert user.goal == 5000
+
+
+def test_update_goal_set_none():
+    crud.create_user("goal2@test.com", "A", "B", "goaluser2", "pass")
+    crud.update_goal("goal2@test.com", 5000)
+    success, user = crud.update_goal("goal2@test.com", None)
+    assert success is True
+    assert user.goal is None
+
+
+def test_update_goal_user_not_found():
+    success, msg = crud.update_goal("nonexistent@test.com", 5000)
+    assert success is False
+    assert msg == "No account with that email"


### PR DESCRIPTION
In order to be a practical budgeting tool users should be able to set their own monthly goals.

The new CRUD function is shown below. We can either call it with an integer value or None as the amount, as you can see here:
`update_goal(my_email@example.com, 5000)` or `update_goal(my_email@example.com, None)`
This enables a user to choose themselves if they want to set a goal or not.

https://github.com/tmuk26-group-1/budget-tool/blob/2f1ae2540eb13c80f46999e6f255f49a2ff5aa15/db/crud.py#L102-L124

Relevant tests are created as well, both in CI and manual CLI-testing file.

Closes #164 